### PR TITLE
Update weapon casing type used by rifles and sniper rifles

### DIFF
--- a/modelsrc/viewmodels/v_mach_m249para/v_mach_m249para.qc
+++ b/modelsrc/viewmodels/v_mach_m249para/v_mach_m249para.qc
@@ -44,7 +44,7 @@ $sequence "shoot1" {
 	"shoot1.smd"
 	activity "ACT_VM_PRIMARYATTACK" 1
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 	//{ event 5001 0 "1" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 0 "EjectBrass_556 2 90" }
 	snap
@@ -55,7 +55,7 @@ $sequence "shoot2" {
 	"shoot2.smd"
 	activity "ACT_VM_PRIMARYATTACK" 1
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 	//{ event 5001 0 "1" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 0 "EjectBrass_556 2 105" }
 	snap

--- a/modelsrc/viewmodels/v_rif_ak47/v_rif_ak47.qc
+++ b/modelsrc/viewmodels/v_rif_ak47/v_rif_ak47.qc
@@ -40,7 +40,7 @@ $sequence "ak47_fire1" {
 	"ak47_fire1.smd"
 	activity "ACT_VM_PRIMARYATTACK" 1
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 	//{ event 5001 0 "1" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 0 "EjectBrass_762Nato 2 150" }
 	snap
@@ -51,7 +51,7 @@ $sequence "ak47_fire2" {
 	"ak47_fire2.smd"
 	activity "ACT_VM_PRIMARYATTACK" 1
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 	//{ event 5001 0 "1" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 0 "EjectBrass_762Nato 2 150" }
 	snap
@@ -62,7 +62,7 @@ $sequence "ak47_fire3" {
 	"ak47_fire3.smd"
 	activity "ACT_VM_PRIMARYATTACK" 1
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 	//{ event 5001 0 "1" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 0 "EjectBrass_762Nato 2 150" }
 	snap

--- a/modelsrc/viewmodels/v_rif_aug/v_rif_aug.qc
+++ b/modelsrc/viewmodels/v_rif_aug/v_rif_aug.qc
@@ -41,7 +41,7 @@ $sequence "shoot1" {
 	"shoot1.smd"
 	activity "ACT_VM_PRIMARYATTACK" 1
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 	//{ event 5001 0 "1" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 0 "EjectBrass_762Nato 2 150" }
 	snap
@@ -52,7 +52,7 @@ $sequence "shoot2" {
 	"shoot2.smd"
 	activity "ACT_VM_PRIMARYATTACK" 2
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 	//{ event 5001 0 "1" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 0 "EjectBrass_762Nato 2 150" }
 	snap
@@ -63,7 +63,7 @@ $sequence "shoot3" {
 	"shoot3.smd"
 	activity "ACT_VM_PRIMARYATTACK" 3
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 	//{ event 5001 0 "1" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 0 "EjectBrass_762Nato 2 150" }
 	snap

--- a/modelsrc/viewmodels/v_rif_famas/v_rif_famas.qc
+++ b/modelsrc/viewmodels/v_rif_famas/v_rif_famas.qc
@@ -56,7 +56,7 @@ $sequence "shoot1" {
 	"shoot1.smd"
 	activity "ACT_VM_PRIMARYATTACK" 1
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 	//{ event 5001 0 "1" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 0 "EjectBrass_556 2 130" }
 	snap
@@ -67,7 +67,7 @@ $sequence "shoot2" {
 	"shoot2.smd"
 	activity "ACT_VM_PRIMARYATTACK" 1
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 	//{ event 5001 0 "1" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 0 "EjectBrass_556 2 125" }
 	snap
@@ -78,7 +78,7 @@ $sequence "shoot3" {
 	"shoot3.smd"
 	activity "ACT_VM_PRIMARYATTACK" 1
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 	//{ event 5001 0 "1" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 0 "EjectBrass_556 2 155" }
 	snap

--- a/modelsrc/viewmodels/v_rif_galil/v_rif_galil.qc
+++ b/modelsrc/viewmodels/v_rif_galil/v_rif_galil.qc
@@ -58,7 +58,7 @@ $sequence "shoot1" {
 	"shoot1.smd"
 	activity "ACT_VM_PRIMARYATTACK" 1
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 	//{ event 5001 0 "1" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 0 "EjectBrass_556 2 75" }
 	snap
@@ -69,7 +69,7 @@ $sequence "shoot2" {
 	"shoot2.smd"
 	activity "ACT_VM_PRIMARYATTACK" 1
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 	//{ event 5001 0 "1" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 0 "EjectBrass_556 2 100" }
 	snap
@@ -80,7 +80,7 @@ $sequence "shoot3" {
 	"shoot3.smd"
 	activity "ACT_VM_PRIMARYATTACK" 1
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 	//{ event 5001 0 "1" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 0 "EjectBrass_556 2 115" }
 	snap

--- a/modelsrc/viewmodels/v_rif_m4a1/v_rif_m4a1.qc
+++ b/modelsrc/viewmodels/v_rif_m4a1/v_rif_m4a1.qc
@@ -41,7 +41,7 @@ $sequence "shoot1" {
 	"shoot1.smd"
 	activity "ACT_VM_PRIMARYATTACK_SILENCED" 1
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE_SIL" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 	//{ event 5001 0 "1" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 0 "EjectBrass_556 2 150" }
 	snap
@@ -52,7 +52,7 @@ $sequence "shoot2" {
 	"shoot2.smd"
 	activity "ACT_VM_PRIMARYATTACK_SILENCED" 1
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE_SIL" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 	//{ event 5001 0 "1" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 0 "EjectBrass_556 2 150" }
 	snap
@@ -63,7 +63,7 @@ $sequence "shoot3" {
 	"shoot3.smd"
 	activity "ACT_VM_PRIMARYATTACK_SILENCED" 1
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE_SIL" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 	//{ event 5001 0 "1" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 0 "EjectBrass_556 2 150" }
 	snap
@@ -105,7 +105,7 @@ $sequence "shoot1_unsil" {
 	"shoot1_unsil.smd"
 	activity "ACT_VM_PRIMARYATTACK" 1
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 	//{ event 5001 0 "1" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 0 "EjectBrass_556 2 150" }
 	snap
@@ -116,7 +116,7 @@ $sequence "shoot2_unsil" {
 	"shoot2_unsil.smd"
 	activity "ACT_VM_PRIMARYATTACK" 1
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 	//{ event 5001 0 "1" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 0 "EjectBrass_556 2 150" }
 	snap
@@ -127,7 +127,7 @@ $sequence "shoot3_unsil" {
 	"shoot3_unsil.smd"
 	activity "ACT_VM_PRIMARYATTACK" 1
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 	//{ event 5001 0 "1" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 0 "EjectBrass_556 2 150" }
 	snap

--- a/modelsrc/viewmodels/v_rif_sg552/v_rif_sg552.qc
+++ b/modelsrc/viewmodels/v_rif_sg552/v_rif_sg552.qc
@@ -62,7 +62,7 @@ $sequence "shoot1" {
 	"shoot1.smd"
 	activity "ACT_VM_PRIMARYATTACK" 1
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 	//{ event 5001 0 "1" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 0 "EjectBrass_556 2 90" }
 	snap
@@ -73,7 +73,7 @@ $sequence "shoot2" {
 	"shoot2.smd"
 	activity "ACT_VM_PRIMARYATTACK" 1
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 	//{ event 5001 0 "1" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 0 "EjectBrass_556 2 90" }
 	snap
@@ -84,7 +84,7 @@ $sequence "shoot3" {
 	"shoot3.smd"
 	activity "ACT_VM_PRIMARYATTACK" 1
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 	//{ event 5001 0 "1" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 0 "EjectBrass_556 2 90" }
 	snap

--- a/modelsrc/viewmodels/v_snip_awp/v_snip_awp.qc
+++ b/modelsrc/viewmodels/v_snip_awp/v_snip_awp.qc
@@ -40,7 +40,7 @@ $sequence "awm_fire" {
 	"awm_fire.smd"
 	activity "ACT_VM_PRIMARYATTACK" 1
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE" }
-	{ event 6001 26 "0" }
+	{ event 6001 26 "1" }
 	//{ event 5001 0 "1" }
 	{ event 5004 15 "Weapon_AWP.Bolt" }
 	{ event 5004 19 "Weapon_AWP.Bolt" }

--- a/modelsrc/viewmodels/v_snip_g3sg1/v_snip_g3sg1.qc
+++ b/modelsrc/viewmodels/v_snip_g3sg1/v_snip_g3sg1.qc
@@ -45,7 +45,7 @@ $sequence "shoot" {
 	"shoot.smd"
 	activity "ACT_VM_PRIMARYATTACK" 1
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 	//{ event 5001 0 "1" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 0 "EjectBrass_762Nato 2 90" }
 	snap
@@ -55,7 +55,7 @@ $sequence "shoot2" {
 	"shoot2.smd"
 	activity "ACT_VM_PRIMARYATTACK" 2
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 	//{ event 5001 0 "1" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 0 "EjectBrass_762Nato 2 90" }
 	snap

--- a/modelsrc/viewmodels/v_snip_scout/v_snip_scout.qc
+++ b/modelsrc/viewmodels/v_snip_scout/v_snip_scout.qc
@@ -41,7 +41,7 @@ $sequence "shoot" {
 	"shoot.smd"
 	activity "ACT_VM_PRIMARYATTACK" 1
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE" }
-	{ event 6001 20 "0" }
+	{ event 6001 20 "1" }
 	//{ event 5001 0 "1" }
 	{ event 5004 13 "Weapon_Scout.Bolt" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 20 "EjectBrass_762Nato 2 40" }

--- a/modelsrc/viewmodels/v_snip_sg550/v_snip_sg550.qc
+++ b/modelsrc/viewmodels/v_snip_sg550/v_snip_sg550.qc
@@ -41,7 +41,7 @@ $sequence "shoot" {
 	"shoot.smd"
 	activity "ACT_VM_PRIMARYATTACK" 1
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 	//{ event 5001 0 "1" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 0 "EjectBrass_556 2 85" }
 	snap
@@ -52,7 +52,7 @@ $sequence "shoot2" {
 	"shoot2.smd"
 	activity "ACT_VM_PRIMARYATTACK" 1
 	{ event AE_MUZZLEFLASH 0 "SMG1 MUZZLE" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 	//{ event 5001 0 "1" }
 	//{ event AE_CLIENT_EFFECT_ATTACH 0 "EjectBrass?556 2 80" }
 	snap

--- a/modelsrc/worldmodels/w_generic_seq_rifle.qci
+++ b/modelsrc/worldmodels/w_generic_seq_rifle.qci
@@ -1,3 +1,34 @@
 
-// For now, just use the SMG QCI
-$include "..\w_generic_seq_smg.qci"
+$sequence "idle" "idle.smd" activity "ACT_VM_IDLE" 1
+
+$sequence "attack1" {
+	"idle.smd" numframes 3
+	activity "ACT_RANGE_ATTACK_SMG1" 1
+	{ event AE_NPC_MUZZLEFLASH 0 "SMG1 MUZZLE" }
+	{ event 3002 0 "" }
+	{ event 6001 0 "1" }
+}
+
+$sequence "attack1a" {
+	"idle.smd" numframes 3
+	activity "ACT_RANGE_ATTACK_AR2" 1
+	{ event AE_NPC_MUZZLEFLASH 0 "SMG1 MUZZLE" }
+	{ event 3002 0 "" }
+	{ event 6001 0 "1" }
+}
+
+$sequence "attack2" {
+	"idle.smd" numframes 3
+	activity "ACT_RANGE_ATTACK_SMG2" 1
+	{ event AE_NPC_MUZZLEFLASH 0 "SMG1 MUZZLE" }
+	{ event 3002 0 "" }
+	{ event 6001 0 "1" }
+}
+
+$sequence "attack2a" {
+	"idle.smd" numframes 3
+	activity "ACT_RANGE_ATTACK_AR1" 1
+	{ event AE_NPC_MUZZLEFLASH 0 "SMG1 MUZZLE" }
+	{ event 3002 0 "" }
+	{ event 6001 0 "1" }
+}

--- a/modelsrc/worldmodels/w_generic_seq_sniperrifle.qci
+++ b/modelsrc/worldmodels/w_generic_seq_sniperrifle.qci
@@ -7,5 +7,5 @@ $sequence "attack3" {
 	activity "ACT_RANGE_ATTACK_SNIPER_RIFLE" 1
 	{ event AE_NPC_MUZZLEFLASH 0 "SMG1 MUZZLE" }
 	{ event 3002 0 "" }
-	{ event 6001 0 "0" }
+	{ event 6001 0 "1" }
 }

--- a/scripts/game_sounds_weapons_css.txt
+++ b/scripts/game_sounds_weapons_css.txt
@@ -1794,7 +1794,7 @@
 
 "Default.ClipEmpty_Rifle"
 {
-	"channel"		"CHAN_WEAPON"
+	"channel"		"CHAN_ITEM"
 	"volume"		"1.0"
 	"CompatibilityAttenuation"	"1.0"
 	"pitch"		"PITCH_NORM"
@@ -1805,7 +1805,7 @@
 
 "Default.ClipEmpty_Pistol"
 {
-	"channel"		"CHAN_WEAPON"
+	"channel"		"CHAN_ITEM"
 	"volume"		"1.0"
 	"CompatibilityAttenuation"	"1.0"
 	"pitch"		"PITCH_NORM"

--- a/scripts/game_sounds_weapons_css.txt
+++ b/scripts/game_sounds_weapons_css.txt
@@ -1794,7 +1794,7 @@
 
 "Default.ClipEmpty_Rifle"
 {
-	"channel"		"CHAN_ITEM"
+	"channel"		"CHAN_WEAPON"
 	"volume"		"1.0"
 	"CompatibilityAttenuation"	"1.0"
 	"pitch"		"PITCH_NORM"
@@ -1805,7 +1805,7 @@
 
 "Default.ClipEmpty_Pistol"
 {
-	"channel"		"CHAN_ITEM"
+	"channel"		"CHAN_WEAPON"
 	"volume"		"1.0"
 	"CompatibilityAttenuation"	"1.0"
 	"pitch"		"PITCH_NORM"


### PR DESCRIPTION
Makes all rifles, sniper rifles and the M249 use the unused rifle casing (models/weapons/rifleshell.mdl) instead of reusing the pistol casing (models/weapons/shell.mdl)


https://github.com/Blixibon/css_weapons_in_hl2/assets/103285866/be300e9b-5817-493c-9d19-a42d3819a435



